### PR TITLE
Add 1.26.1

### DIFF
--- a/plugins/istioctl-build/share/istioctl-build/1.26.1
+++ b/plugins/istioctl-build/share/istioctl-build/1.26.1
@@ -1,0 +1,7 @@
+install_darwin_64bit "istioctl Darwin 64bit 1.26.1" "https://github.com/istio/istio/releases/download/1.26.1/istioctl-1.26.1-osx.tar.gz#56e2e4ac42cb1624fb2c207c784ef75f7b8aeb2e78d08c51abc86dbb95d5ad8c"
+
+install_darwin_arm "istioctl Darwin arm 1.26.1" "https://github.com/istio/istio/releases/download/1.26.1/istioctl-1.26.1-osx-arm64.tar.gz#2dd7d75fecdc158512d09e919afdbfa85fbcdf9a160d646835c8241f597f08ec"
+
+install_linux_64bit "istioctl Linux 64bit 1.26.1" "https://github.com/istio/istio/releases/download/1.26.1/istioctl-1.26.1-linux-amd64.tar.gz#37b2090eeea1201fe21fecede487da5e132700f4981d51d876289f89bd49ffbd"
+
+install_linux_arm_64bit "istioctl Linux arm 64bit 1.26.1" "https://github.com/istio/istio/releases/download/1.26.1/istioctl-1.26.1-linux-arm64.tar.gz#9071b065758c5fe559894207a8b77e3a9b3c1ca62477281bd254f931728c320b"


### PR DESCRIPTION
## WHAT
This pull request updates the `istioctl-build` plugin to include installation scripts for version 1.26.1 across multiple platforms.

Platform-specific installation additions:

* [`plugins/istioctl-build/share/istioctl-build/1.26.1`](diffhunk://#diff-ff8f7fb6fdbdae96528818653405ddb74583edf198b42b5de2f594b0507ec95bR1-R7): Added installation scripts for `istioctl` version 1.26.1 for Darwin 64-bit, Darwin ARM, Linux 64-bit, and Linux ARM 64-bit platforms.
## WHY
