### PR TITLE
Add 1.26.2 and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+istioctlenv is an istioctl version management tool modeled after rbenv and goenv. It allows users to:
+- Manage multiple istioctl versions on a single system
+- Set global and per-project istioctl versions
+- Use shims to intercept istioctl commands and route them to the correct version
+
+## Architecture
+
+The tool follows the standard *env pattern:
+- **Shims**: Lightweight executables in `~/.istioctlenv/shims/` that intercept istioctl commands
+- **Version Resolution**: Checks `ISTIOCTLENV_VERSION` env var → `.istioctl-version` file in current/parent dirs → global `~/.istioctlenv/version` file → system istioctl
+- **Installation Directory**: Each istioctl version is installed in `~/.istioctlenv/versions/<version>/`
+- **Plugin System**: Uses `istioctl-build` plugin for downloading and installing istioctl binaries
+
+## Key Components
+
+- **libexec/**: Contains all istioctlenv commands as individual bash scripts
+- **plugins/istioctl-build/**: Plugin that handles downloading istioctl binaries from Istio releases
+- **completions/**: Shell completion scripts for bash, zsh, and fish
+- **scripts/gen_new_build.sh**: Utility to generate build definitions for new istioctl versions
+
+## Common Commands
+
+### Development
+- `./scripts/gen_new_build.sh <version>` - Generate build definition for a new istioctl version
+- Check plugins/istioctl-build/share/istioctl-build/ for available versions
+
+### Testing
+- No automated test suite present
+- Manual testing involves installing versions and verifying shim behavior
+
+### Installation Management
+- `istioctlenv install <version>` - Install a specific istioctl version
+- `istioctlenv global <version>` - Set global istioctl version
+- `istioctlenv local <version>` - Set local istioctl version for current directory
+- `istioctlenv versions` - List all installed versions
+- `istioctlenv rehash` - Regenerate shims after installation
+
+## Build Definitions
+
+New istioctl versions are added by:
+1. Running `./scripts/gen_new_build.sh <version>` to generate build file
+2. The script fetches release assets from GitHub API and creates installation definitions
+3. Build files are stored in `plugins/istioctl-build/share/istioctl-build/<version>`
+
+## Shell Integration
+
+The tool requires shell integration via `eval "$(istioctlenv init -)"` to:
+- Add shims directory to PATH
+- Enable shell completion
+- Set up environment for version switching
+
+## Release Process
+
+- When we add a new version, execute `./scripts/gen_new_build.sh`.
+  e.g. `./scripts/gen_new_build.sh 1.26.1`
+
+## GitHub Pull Requests
+
+- When you open a GitHub PR, please must to use template in .github/PULL_REQUEST_TEMPLATE.md

--- a/plugins/istioctl-build/share/istioctl-build/1.26.2
+++ b/plugins/istioctl-build/share/istioctl-build/1.26.2
@@ -1,0 +1,7 @@
+install_darwin_64bit "istioctl Darwin 64bit 1.26.2" "https://github.com/istio/istio/releases/download/1.26.2/istioctl-1.26.2-osx.tar.gz#28f911509bbe93a968225b8e380500c8ab9eb998f3a497c20eb28bc20ba0cc03"
+
+install_darwin_arm "istioctl Darwin arm 1.26.2" "https://github.com/istio/istio/releases/download/1.26.2/istioctl-1.26.2-osx-arm64.tar.gz#e6977f35c8b547d1ae404074e2981f80d980c477786436007259a7e895748dfe"
+
+install_linux_64bit "istioctl Linux 64bit 1.26.2" "https://github.com/istio/istio/releases/download/1.26.2/istioctl-1.26.2-linux-amd64.tar.gz#1dddf567813b5bc92a3ffd64cba62e973f73f7e54a89a30be6e2a0104c5a0319"
+
+install_linux_arm_64bit "istioctl Linux arm 64bit 1.26.2" "https://github.com/istio/istio/releases/download/1.26.2/istioctl-1.26.2-linux-arm64.tar.gz#752f2939a969c1defa70f502165033a6f9ad2c30684f1bcebdf57292acc38abc"


### PR DESCRIPTION
## WHAT
Add support for istioctl version 1.26.2 by generating the build definition file.

## WHY
Enable users to install and use istioctl version 1.26.2 through istioctlenv.

🤖 Generated with [Claude Code](https://claude.ai/code)