### PR TITLE
Add Claude command for adding new istioctl versions

### DIFF
--- a/.claude/commands/add-version.md
+++ b/.claude/commands/add-version.md
@@ -1,0 +1,10 @@
+# Add Version
+
+## Goal
+
+Add a Istio $ARGUMENTS version to istioctlenv
+
+## Steps
+
+1. Runs `./scripts/gen_new_build.sh <version>`
+2. Open a GitHub pull request with the changes


### PR DESCRIPTION
## WHAT

Adds `.claude/commands/add-version.md` to provide Claude Code with a command definition for adding new istioctl versions to istioctlenv.

## WHY

This enables Claude Code to understand and assist with the process of adding new istioctl versions using the existing `./scripts/gen_new_build.sh` script, making it easier to maintain and extend the tool with new Istio releases.

🤖 Generated with [Claude Code](https://claude.ai/code)